### PR TITLE
Update fire-weapon-hook.js

### DIFF
--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -146,7 +146,7 @@ Hooks.on(
                         const ammo = Utils.getAmmunition(weapon);
                         itemsToUpdate.push(async () => {
                             await ammo.update({
-                                "data.quantity.value": ammo.quantity - 1
+                                "data.quantity": ammo.quantity - 1
                             });
                         });
                         Utils.postInChat(actor, ammo.img, `${actor.name} uses ${ammo.name}.`);


### PR DESCRIPTION
Replaced all accounts of `quantity.value` for ammunition with just `quantity`. This has been done blind and not tested yet.